### PR TITLE
Update uses.yaml to reflect current machine setup

### DIFF
--- a/src/routes/uses/+page.svelte
+++ b/src/routes/uses/+page.svelte
@@ -118,15 +118,6 @@
 			>.
 		</p>
 
-		{#if meta && meta.affiliateDisclaimer}
-			<div class="my-8 rounded-lg bg-gray-100 p-6 dark:bg-gray-800">
-				<h2 class="mb-3 text-2xl font-medium">A note about links</h2>
-				<p class="text-gray-600 dark:text-gray-400">
-					{meta.affiliateDisclaimer}
-				</p>
-			</div>
-		{/if}
-
 		{#if isLoading}
 			<div class="flex justify-center py-12">
 				<div class="animate-pulse text-xl text-gray-600 dark:text-gray-400">Loading...</div>
@@ -139,8 +130,21 @@
 				</p>
 			</div>
 		{:else}
-			<div class="mb-8">
-				<div class="flex flex-wrap gap-2">
+			<details class="mb-8">
+				<summary
+					class="flex cursor-pointer select-none list-none items-center gap-2 text-sm font-medium text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400 [&::-webkit-details-marker]:hidden"
+				>
+					<Icon icon="mdi:filter-variant" class="h-4 w-4" />
+					<span>Filter by tag</span>
+					{#if selectedTags.size > 0}
+						<span
+							class="rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-800 dark:bg-blue-900/50 dark:text-blue-300"
+						>
+							{selectedTags.size} selected
+						</span>
+					{/if}
+				</summary>
+				<div class="mt-3 flex flex-wrap gap-2">
 					{#each allTags as tag}
 						<button
 							onclick={() => toggleTag(tag)}
@@ -153,22 +157,14 @@
 					{/each}
 				</div>
 				{#if selectedTags.size > 0}
-					<div class="mt-4 flex items-center">
-						<button
-							onclick={() => (selectedTags = new Set())}
-							class="text-sm text-blue-600 hover:underline dark:text-blue-400"
-						>
-							Clear all filters
-						</button>
-						<span
-							class="ml-2 rounded-full bg-blue-100 px-2 py-0.5 text-sm text-blue-800 dark:bg-blue-900/50 dark:text-blue-300"
-						>
-							{selectedTags.size}
-							{selectedTags.size === 1 ? 'tag' : 'tags'} selected
-						</span>
-					</div>
+					<button
+						onclick={() => (selectedTags = new Set())}
+						class="mt-3 text-sm text-blue-600 hover:underline dark:text-blue-400"
+					>
+						Clear all filters
+					</button>
 				{/if}
-			</div>
+			</details>
 
 			{#if items.filter((item) => shouldDisplayItem(item)).length === 0}
 				<div class="my-12 rounded-lg bg-gray-100 p-8 text-center dark:bg-gray-800">
@@ -231,10 +227,13 @@
 				{/each}
 			{/if}
 
-			<div class="mt-12">
-				<p class="text-gray-600 dark:text-gray-400">
-					Last updated: {meta?.lastUpdated}
-				</p>
+			<div
+				class="mt-12 space-y-1 border-t border-gray-200 pt-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-500"
+			>
+				<p>Last updated: {meta?.lastUpdated}</p>
+				{#if meta?.affiliateDisclaimer}
+					<p>{meta.affiliateDisclaimer}</p>
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/src/routes/uses/+page.svelte
+++ b/src/routes/uses/+page.svelte
@@ -189,7 +189,7 @@
 					{#if categoryItems.length > 0}
 						<section class="mb-10">
 							<h2
-								class="mb-4 border-b border-gray-200 pb-2 text-sm font-semibold tracking-wide text-gray-500 uppercase dark:border-gray-700 dark:text-gray-400"
+								class="mb-4 border-b border-gray-200 pb-2 text-sm font-semibold uppercase tracking-wide text-gray-500 dark:border-gray-700 dark:text-gray-400"
 							>
 								{category}
 							</h2>

--- a/src/routes/uses/+page.svelte
+++ b/src/routes/uses/+page.svelte
@@ -8,6 +8,7 @@
 		name: string;
 		description: string;
 		url: string;
+		category?: string;
 		tags?: string[];
 	}
 
@@ -23,8 +24,18 @@
 
 	// State variables
 	let items: UsesItem[] = [];
+	let categories: string[] = [];
 	let allTags: string[] = [];
 	let selectedTags: Set<string> = new Set();
+
+	const UNCATEGORIZED = 'Other';
+
+	// Items in a category that pass the current tag filter, sorted by name
+	function itemsForCategory(category: string): UsesItem[] {
+		return items
+			.filter((item) => (item.category ?? UNCATEGORIZED) === category && shouldDisplayItem(item))
+			.sort((a, b) => a.name.localeCompare(b.name));
+	}
 	let meta: UsesMeta | null = null;
 	let isLoading = true;
 	let loadError = false;
@@ -59,8 +70,15 @@
 			const yamlText = await response.text();
 			const data = yaml.load(yamlText) as UsesData;
 
-			// Sort items alphabetically by name
-			items = [...data.items].sort((a, b) => a.name.localeCompare(b.name));
+			items = data.items;
+
+			// Build the category list in first-seen order from the YAML
+			const categoryOrder: string[] = [];
+			items.forEach((item) => {
+				const category = item.category ?? UNCATEGORIZED;
+				if (!categoryOrder.includes(category)) categoryOrder.push(category);
+			});
+			categories = categoryOrder;
 
 			// Extract all unique tags and sort them alphabetically
 			const tagSet = new Set<string>();
@@ -166,41 +184,51 @@
 					</button>
 				</div>
 			{:else}
-				<div class="flex flex-wrap gap-6">
-					{#each items as item}
-						{#if shouldDisplayItem(item)}
-							<div
-								class="flex-grow rounded-lg border border-gray-200 p-4 transition-all hover:shadow-md dark:border-gray-700"
+				{#each categories as category}
+					{@const categoryItems = itemsForCategory(category)}
+					{#if categoryItems.length > 0}
+						<section class="mb-10">
+							<h2
+								class="mb-4 border-b border-gray-200 pb-2 text-sm font-semibold tracking-wide text-gray-500 uppercase dark:border-gray-700 dark:text-gray-400"
 							>
-								<h3 class="mb-1 text-xl font-medium">
-									<a
-										href={item.url}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="text-blue-600 hover:underline dark:text-blue-400"
+								{category}
+							</h2>
+							<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+								{#each categoryItems as item}
+									<div
+										class="rounded-lg border border-gray-200 p-4 transition-all hover:shadow-md dark:border-gray-700"
 									>
-										{item.name}
-									</a>
-								</h3>
-								<p class="mb-2 text-gray-600 dark:text-gray-400">{item.description}</p>
-								<div class="flex flex-wrap gap-2">
-									{#each item.tags ?? [] as tag}
-										<button
-											onclick={() => toggleTag(tag)}
-											class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 {selectedTags.has(
-												tag
-											)
-												? 'ring-1 ring-blue-400 dark:ring-blue-500'
-												: ''}"
-										>
-											{tag}
-										</button>
-									{/each}
-								</div>
+										<h3 class="mb-1 text-xl font-medium">
+											<a
+												href={item.url}
+												target="_blank"
+												rel="noopener noreferrer"
+												class="text-blue-600 hover:underline dark:text-blue-400"
+											>
+												{item.name}
+											</a>
+										</h3>
+										<p class="mb-2 text-gray-600 dark:text-gray-400">{item.description}</p>
+										<div class="flex flex-wrap gap-2">
+											{#each item.tags ?? [] as tag}
+												<button
+													onclick={() => toggleTag(tag)}
+													class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 {selectedTags.has(
+														tag
+													)
+														? 'ring-1 ring-blue-400 dark:ring-blue-500'
+														: ''}"
+												>
+													{tag}
+												</button>
+											{/each}
+										</div>
+									</div>
+								{/each}
 							</div>
-						{/if}
-					{/each}
-				</div>
+						</section>
+					{/if}
+				{/each}
 			{/if}
 
 			<div class="mt-12">

--- a/static/data/uses.yaml
+++ b/static/data/uses.yaml
@@ -1,43 +1,13 @@
 items:
-  - name: HP Z2 Mini G4 Workstation
+  - name: Apple MacBook Air (M5)
     description: My primary development machine
-    url: https://amzn.to/4jOvjuv
+    url: https://www.apple.com/macbook-air/
     tags: [workstation, development, hardware]
 
-  - name: Samsung 24" T350 LED monitor, LF24T350FHNXZA
-    description: Monitor
-    url: https://amzn.to/3F7F8o1
-    tags: [monitor, hardware, workstation]
-
-  - name: ASUS VN279QL 27" 1920x1080 monitor
-    description: Monitor
-    url: https://amzn.to/44sVouj
-    tags: [monitor, hardware, workstation]
-
-  - name: Monoprice Workstream USB keyboard
-    description: Basic wired keyboard
-    url: https://www.monoprice.com/product?p_id=35106
-    tags: [keyboard, hardware, workstation]
-
-  - name: Monoprice Essential USB optical mouse
-    description: Ergonomic wireless mouse
-    url: https://www.monoprice.com/product?p_id=15907
-    tags: [mouse, hardware, workstation]
-
-  - name: VIVO 42" Standing Desk Converter
-    description: Standing desk converter
-    url: https://amzn.to/4jVgGFF
-    tags: [desk, hardware, workstation]
-
-  - name: Debian
-    description: Linux distribution
-    url: https://www.debian.org/
+  - name: macOS
+    description: Operating system
+    url: https://www.apple.com/macos/
     tags: [os, software, productivity]
-
-  - name: i3
-    description: Tiling window manager
-    url: https://i3wm.org/
-    tags: [wm, software, productivity]
 
   - name: Obsidian
     description: Notes
@@ -59,20 +29,30 @@ items:
     url: https://zed.dev/
     tags: [ide, software, development, ai]
 
+  - name: Ghostty
+    description: Fast, native terminal emulator
+    url: https://ghostty.org/
+    tags: [terminal, software]
+
   - name: Warp
     description: Terminal with AI & multiplayer features
     url: https://app.warp.dev/referral/ME5ELJ
     tags: [terminal, software, ai]
 
-  - name: Codebuff
+  - name: Claude Code
     description: Terminal-based agentic AI coding assistant
-    url: https://codebuff.com/referrals/ref-6d348d54-80f1-4155-903b-2cc6c57dd12f
+    url: https://www.anthropic.com/claude-code
     tags: [terminal, software, ai]
 
   - name: Node.js
     description: JavaScript runtime
     url: https://nodejs.org/
     tags: [development, runtime, webdev]
+
+  - name: Go
+    description: Programming language
+    url: https://go.dev/
+    tags: [development, language]
 
   - name: Svelte & SvelteKit
     description: Framework for building web applications
@@ -189,9 +169,9 @@ items:
     url: https://pnpm.io/
     tags: [development, cli, terminal]
 
-  - name: Convex
-    description: Serverless backend-as-a-service
-    url: https://convex.dev/
+  - name: Supabase
+    description: Open-source Firebase alternative (Postgres backend-as-a-service)
+    url: https://supabase.com/
     tags: [development, platform, framework, webdev]
 
   - name: NestJS
@@ -230,5 +210,5 @@ items:
     tags: [development, webdev]
 
 meta:
-  lastUpdated: '2025-05-08'
+  lastUpdated: '2026-06-26'
   affiliateDisclaimer: 'Some links on this page might be affiliate links. This means I may earn a small commission if you purchase a product through these links, at no extra cost to you.'

--- a/static/data/uses.yaml
+++ b/static/data/uses.yaml
@@ -1,213 +1,246 @@
 items:
+  # Hardware
   - name: Apple MacBook Air (M5)
     description: My primary development machine
     url: https://www.apple.com/macbook-air/
+    category: Hardware
     tags: [workstation, development, hardware]
 
+  # Apps
   - name: macOS
     description: Operating system
     url: https://www.apple.com/macos/
+    category: Apps
     tags: [os, software, productivity]
 
   - name: Obsidian
     description: Notes
     url: https://obsidian.md/
+    category: Apps
     tags: [notes, software, productivity]
 
   - name: Beeminder
     description: Goal tracking with real stakes
     url: https://www.beeminder.com/home
+    category: Apps
     tags: [productivity, software]
 
   - name: Slack
     description: Communication
     url: https://slack.com/
+    category: Apps
     tags: [communication, software, productivity]
 
+  # Editors & Terminal
   - name: Zed
     description: IDE with AI & multiplayer features
     url: https://zed.dev/
+    category: Editors & Terminal
     tags: [ide, software, development, ai]
 
   - name: Ghostty
     description: Fast, native terminal emulator
     url: https://ghostty.org/
+    category: Editors & Terminal
     tags: [terminal, software]
 
   - name: Warp
     description: Terminal with AI & multiplayer features
     url: https://app.warp.dev/referral/ME5ELJ
+    category: Editors & Terminal
     tags: [terminal, software, ai]
 
   - name: Claude Code
     description: Terminal-based agentic AI coding assistant
     url: https://www.anthropic.com/claude-code
+    category: Editors & Terminal
     tags: [terminal, software, ai]
 
-  - name: Node.js
-    description: JavaScript runtime
-    url: https://nodejs.org/
-    tags: [development, runtime, webdev]
-
-  - name: Go
-    description: Programming language
-    url: https://go.dev/
-    tags: [development, language]
-
-  - name: Svelte & SvelteKit
-    description: Framework for building web applications
-    url: https://svelte.dev/
-    tags: [development, framework, webdev]
-
-  - name: GitHub
-    description: Hosted version control
-    url: https://github.com/
-    tags: [development, git, versioncontrol]
-
-  - name: Carrd
-    description: Single-page website builder
-    url: https://try.carrd.co/d3zxlsms
-    tags: [development, webdev]
-
+  # Languages
   - name: JavaScript
     description: Programming language
     url: https://developer.mozilla.org/en-US/docs/Web/JavaScript
+    category: Languages
     tags: [development, language, webdev]
 
   - name: TypeScript
     description: Typed superset of JavaScript
     url: https://www.typescriptlang.org/
+    category: Languages
     tags: [development, language, webdev]
+
+  - name: Ruby
+    description: Programming language
+    url: https://www.ruby-lang.org/
+    category: Languages
+    tags: [development, language, webdev]
+
+  - name: Go
+    description: Programming language
+    url: https://go.dev/
+    category: Languages
+    tags: [development, language]
+
+  # Frameworks & Libraries
+  - name: Svelte & SvelteKit
+    description: Framework for building web applications
+    url: https://svelte.dev/
+    category: Frameworks & Libraries
+    tags: [development, framework, webdev]
 
   - name: React
     description: JavaScript library for building user interfaces
     url: https://reactjs.org/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
 
   - name: Vue.js
     description: Progressive JavaScript framework
     url: https://vuejs.org/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
 
   - name: Tailwind CSS
     description: Utility-first CSS framework
     url: https://tailwindcss.com/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
 
   - name: Next.js
     description: React framework for production
     url: https://nextjs.org/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
-
-  - name: Docker
-    description: Containerization platform
-    url: https://www.docker.com/
-    tags: [development, software, containerization]
-
-  - name: Git
-    description: Version control system
-    url: https://git-scm.com/
-    tags: [development, cli, terminal, git, versioncontrol]
-
-  - name: Ruby
-    description: Programming language
-    url: https://www.ruby-lang.org/
-    tags: [development, language, webdev]
 
   - name: Ruby on Rails
     description: Web application framework
     url: https://rubyonrails.org/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
-
-  - name: ASDF
-    description: Plugin-based version manager
-    url: https://asdf-vm.com/
-    tags: [development, cli, terminal, software]
-
-  - name: Render.com
-    description: Cloud platform
-    url: https://render.com/
-    tags: [development, cloud, platform, webdev]
-
-  - name: Cloudflare
-    description: Cloud platform
-    url: https://www.cloudflare.com/
-    tags: [development, cloud, platform, webdev]
-
-  - name: Vercel
-    description: Cloud platform
-    url: https://vercel.com/
-    tags: [development, cloud, platform, webdev]
-
-  - name: Netlify
-    description: Cloud platform
-    url: https://www.netlify.com/
-    tags: [development, cloud, platform, webdev]
 
   - name: Astro
     description: Static site generator
     url: https://astro.build/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
-
-  - name: REST
-    description: Representational State Transfer
-    url: https://restfulapi.net/
-    tags: [development, webdev]
-
-  - name: GraphQL
-    description: Query language for APIs
-    url: https://graphql.org/
-    tags: [development, webdev]
 
   - name: Hono
     description: Lightweight web framework for Node.js
     url: https://hono.dev/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
-
-  - name: pnpm
-    description: Node package manager
-    url: https://pnpm.io/
-    tags: [development, cli, terminal]
-
-  - name: Supabase
-    description: Open-source Firebase alternative (Postgres backend-as-a-service)
-    url: https://supabase.com/
-    tags: [development, platform, framework, webdev]
 
   - name: NestJS
     description: Progressive Node.js server-side framework
     url: https://nestjs.com/
+    category: Frameworks & Libraries
     tags: [development, framework, webdev]
 
   - name: React Query
     description: Data fetching and state management library for React applications
     url: https://react-query.tanstack.com/
+    category: Frameworks & Libraries
     tags: [development, webdev]
 
+  # APIs
+  - name: REST
+    description: Representational State Transfer
+    url: https://restfulapi.net/
+    category: APIs
+    tags: [development, webdev]
+
+  - name: GraphQL
+    description: Query language for APIs
+    url: https://graphql.org/
+    category: APIs
+    tags: [development, webdev]
+
+  # Testing
   - name: React Testing Library
     description: Testing library for React components
     url: https://testing-library.com/docs/react-testing-library/intro/
+    category: Testing
     tags: [development, webdev, testing]
 
   - name: Jest
     description: JavaScript testing framework
     url: https://jestjs.io/
+    category: Testing
     tags: [development, webdev, testing]
 
   - name: Vitest
     description: JavaScript testing framework
     url: https://vitest.dev/
+    category: Testing
     tags: [development, webdev, testing]
 
-  - name: Google Cloud Platform
-    description: Cloud computing platform
-    url: https://cloud.google.com/
-    tags: [development, platform, webdev]
+  # Tooling
+  - name: Node.js
+    description: JavaScript runtime
+    url: https://nodejs.org/
+    category: Tooling
+    tags: [development, runtime, webdev]
+
+  - name: Git
+    description: Version control system
+    url: https://git-scm.com/
+    category: Tooling
+    tags: [development, cli, terminal, git, versioncontrol]
+
+  - name: GitHub
+    description: Hosted version control
+    url: https://github.com/
+    category: Tooling
+    tags: [development, git, versioncontrol]
+
+  - name: Docker
+    description: Containerization platform
+    url: https://www.docker.com/
+    category: Tooling
+    tags: [development, software, containerization]
+
+  - name: ASDF
+    description: Plugin-based version manager
+    url: https://asdf-vm.com/
+    category: Tooling
+    tags: [development, cli, terminal, software]
+
+  - name: pnpm
+    description: Node package manager
+    url: https://pnpm.io/
+    category: Tooling
+    tags: [development, cli, terminal]
 
   - name: Vite
     description: JavaScript frontend tooling
     url: https://vitejs.dev/
+    category: Tooling
     tags: [development, webdev]
+
+  # Hosting & Cloud
+  - name: Render.com
+    description: Cloud platform
+    url: https://render.com/
+    category: Hosting & Cloud
+    tags: [development, cloud, platform, webdev]
+
+  - name: Cloudflare
+    description: Cloud platform
+    url: https://www.cloudflare.com/
+    category: Hosting & Cloud
+    tags: [development, cloud, platform, webdev]
+
+  - name: Netlify
+    description: Cloud platform
+    url: https://www.netlify.com/
+    category: Hosting & Cloud
+    tags: [development, cloud, platform, webdev]
+
+  - name: Google Cloud Platform
+    description: Cloud computing platform
+    url: https://cloud.google.com/
+    category: Hosting & Cloud
+    tags: [development, platform, webdev]
 
 meta:
   lastUpdated: '2026-06-26'


### PR DESCRIPTION
Audited `static/data/uses.yaml` against the actual local machine (MacBook Air M5, macOS 26.4) and corrected stale entries.

## Changes
- **Machine:** HP Z2 Mini G4 → MacBook Air (M5)
- **OS/WM:** Debian → macOS; removed i3 (no tiling WM on macOS)
- **Peripherals removed:** monitors, Monoprice keyboard/mouse, VIVO desk (now a laptop-only setup)
- **AI/terminal:** swapped Codebuff → Claude Code; added Ghostty
- **Added:** Go, Supabase
- **Removed:** Convex (no longer used)
- Bumped `lastUpdated` to 2026-06-26

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed the “uses” page data with a new setup, including an Apple MacBook Air (M5) and macOS.
  * Updated the tooling list to include Ghostty, Claude Code, and Go, with some older entries removed.
  * Swapped the backend service listed on the page from Convex to Supabase.
  * Updated the page’s “last updated” date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->