### PR TITLE
fix(ci): make Cloudflare deploy actually work (wrangler 4 + hardening)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,5 +26,7 @@ jobs:
       - run: pnpm run build
       - uses: cloudflare/wrangler-action@v3
         with:
+          # v3 defaults to wrangler 3.90, which lacks assets-only Worker support
+          wranglerVersion: "4"
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,19 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: cloudflare/wrangler-action@v3
         with:
           # v3 defaults to wrangler 3.90, which lacks assets-only Worker support
-          wranglerVersion: "4"
+          wranglerVersion: '4'
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The deploy workflow merged in #66 failed on first run:

> ✘ [ERROR] Missing entry-point: The entry-point should be specified via the command line or the \`main\` config field.

`wrangler-action@v3` defaults to wrangler **3.90**, which predates assets-only Worker support and demands a `main` entry-point. Pinning `wranglerVersion: "4"` fixes it (matches the 4.x local dry-run that passed).

This branch also carries the workflow hardening (concurrency group, least-privilege `permissions`, `persist-credentials: false`) that landed after #66 was already merged, so it never reached master.

## Changes
- `wranglerVersion: "4"` on `cloudflare/wrangler-action`
- workflow `concurrency` group
- `permissions: contents: read`
- `persist-credentials: false` on checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)